### PR TITLE
Caching regular expressions using static_init crate

### DIFF
--- a/src/document/spreadsheet/mod.rs
+++ b/src/document/spreadsheet/mod.rs
@@ -5,6 +5,8 @@ use std::{cell::RefCell, path::Path, rc::Rc};
 // use derivative::Derivative;
 use derivative::Derivative;
 
+use static_init::dynamic;
+
 use crate::{
     error::Result,
     packaging::element::*,
@@ -156,6 +158,29 @@ pub struct Worksheet {
     part: WorksheetPart,
 }
 
+#[dynamic(lazy)]
+static DATETIME_RE: regex::Regex = regex::Regex::new("y{1,4}|m{1,5}|d+|h|ss|a{2,5}").unwrap();
+
+#[dynamic(lazy)]
+static DATETIME_REPLACES: Vec<(regex::Regex, &'static str)> = vec![
+    (regex::Regex::new(":mm").unwrap(), ":%M"),
+    (regex::Regex::new("mm:").unwrap(), "%M:"),
+    (regex::Regex::new("mm").unwrap(), "%m"),
+    (regex::Regex::new("yyyy+").unwrap(), "%Y"),
+    (regex::Regex::new("yy+").unwrap(), "%y"),
+    (regex::Regex::new("mmmm+").unwrap(), "%B"),
+    (regex::Regex::new("mmm").unwrap(), "%b"),
+    (regex::Regex::new("([^%]|^)m").unwrap(), "$1%-m"),
+    (regex::Regex::new("d{2,}").unwrap(), "%d"),
+    (regex::Regex::new("d{1}").unwrap(), "%-d"),
+    (regex::Regex::new("a{4,}").unwrap(), "%A"),
+    (regex::Regex::new("a{3}").unwrap(), "%a"),
+    (regex::Regex::new("a{2}").unwrap(), "%w"),
+    (regex::Regex::new("h").unwrap(), "%H"),
+    (regex::Regex::new("ss").unwrap(), "%S"),
+    (regex::Regex::new("\\\\").unwrap(), ""),
+];
+
 impl Worksheet {
     pub fn dimenstion(&self) -> Option<(usize, usize)> {
         // self.part.dimension()
@@ -212,34 +237,14 @@ impl Worksheet {
                 None
             }
         }
-        let datetime_re = regex::Regex::new("y{1,4}|m{1,5}|d+|h|ss|a{2,5}").unwrap();
-
-        let datetime_replaces = vec![
-            (regex::Regex::new(":mm").unwrap(), ":%M"),
-            (regex::Regex::new("mm:").unwrap(), "%M:"),
-            (regex::Regex::new("mm").unwrap(), "%m"),
-            (regex::Regex::new("yyyy+").unwrap(), "%Y"),
-            (regex::Regex::new("yy+").unwrap(), "%y"),
-            (regex::Regex::new("mmmm+").unwrap(), "%B"),
-            (regex::Regex::new("mmm").unwrap(), "%b"),
-            (regex::Regex::new("([^%]|^)m").unwrap(), "$1%-m"),
-            (regex::Regex::new("d{2,}").unwrap(), "%d"),
-            (regex::Regex::new("d{1}").unwrap(), "%-d"),
-            (regex::Regex::new("a{4,}").unwrap(), "%A"),
-            (regex::Regex::new("a{3}").unwrap(), "%a"),
-            (regex::Regex::new("a{2}").unwrap(), "%w"),
-            (regex::Regex::new("h").unwrap(), "%H"),
-            (regex::Regex::new("ss").unwrap(), "%S"),
-            (regex::Regex::new("\\\\").unwrap(), ""),
-        ];
         let s = match code {
             s if s == "General" => CellValue::String(raw.to_string()),
-            format if datetime_re.is_match(format) | format.ends_with(";@") => {
+            format if DATETIME_RE.is_match(format) | format.ends_with(";@") => {
                 // dbg!(&format);
                 let format = format.trim_end_matches(";@");
                 let datetime = parse_datetime(raw).unwrap();
 
-                let format = datetime_replaces
+                let format = DATETIME_REPLACES
                     .iter()
                     .fold(escape8259::unescape(format).unwrap(), |f, (re, s)| {
                         re.replace_all(&f, *s).to_string()

--- a/src/document/spreadsheet/worksheet.rs
+++ b/src/document/spreadsheet/worksheet.rs
@@ -6,6 +6,11 @@ use quick_xml::events::attributes::Attribute;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+use static_init::dynamic;
+
+#[dynamic(lazy)]
+static DIMENSION_RE: regex::Regex = regex::Regex::new(r"(?P<col>[A-Z]+)(?P<row>\d+)").unwrap();
+
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", rename = "sheetPr")]
 pub struct SheetPr {}
@@ -61,8 +66,7 @@ impl Dimension {
         let end = range[1];
         //let (start, end) = range.split_once(':').expect("split at :");
         fn rangify(range: &str) -> (usize, usize) {
-            let re: regex::Regex = regex::Regex::new(r"(?P<col>[A-Z]+)(?P<row>\d+)").unwrap();
-            let cap = re.captures(range).unwrap();
+            let cap = DIMENSION_RE.captures(range).unwrap();
             let col = cap.name("col").unwrap().as_str();
             let row = cap
                 .name("row")


### PR DESCRIPTION
I noticed that https://github.com/zitsen/xlsx2csv.rs is significantly slower than https://github.com/dilshod/xlsx2csv, and found some low hanging fruits in this library. Caching regular expressions allowed to reduce processing time of an 11Mb XLSX file from 13:53.80 to just 13.755 seconds, basically most of it. Which, sadly, is still a bit more than the Python version (12.23 seconds), I guess it's because the Python one uses lxml, which in turn uses libxml2 under the hood.

Apologies for the typo in the branch name.